### PR TITLE
A build fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install MinGW (GCC for Windows)
-        uses: egor-tensin/setup-mingw@v2
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
         with:
-          platform: x64
+          msystem: MINGW64
+          install: mingw-w64-x86_64-gcc
 
       - name: Build executable
+        shell: msys2 {0}
         run: gcc -o digitalclock.exe digital_clock_win32.c -mwindows -luser32 -lgdi32
 
       - name: Upload build artifact


### PR DESCRIPTION
There was an error occurring during the MinGW installation step in GitHub Actions workflow. Chocolatey successfully installed MinGW v13.2.0 (the 'upgrade of mingw was successful'). The PATH was updated to include the GCC binaries. However, the installation script tried to remove a file (libpthread.dll.a) that doesn't exist in this MinGW version/build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated Windows build environment to MSYS2 with a standardized GCC toolchain.
  * Updated build steps to use a consistent MSYS2 shell for compiling executables.
  * Improves reliability and consistency of Windows build artifacts.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->