### PR TITLE
A release patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v1.0.0)'
+        description: "Version tag (e.g., v1.0.0)"
         required: true
-        default: 'v1.0.0'
+        default: "v1.0.0"
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   build:
@@ -53,3 +57,4 @@ jobs:
           files: dist/digitalclock.exe
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           name: Release ${{ github.event.inputs.version || github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
The issue was that the default GITHUB_TOKEN didn't have explicit permission to create releases in your repository.